### PR TITLE
animation value should be scaled

### DIFF
--- a/src/modules/animation.js
+++ b/src/modules/animation.js
@@ -83,7 +83,7 @@ function transitionOnce (vnode, config, callback) {
   }
   nextFrame(() => {
     dom.style.cssText
-      += toCSSText(styleObject2rem(config.styles, 75) || {})
+      += toCSSText(styleObject2rem(config.styles, weex.config.env.rootValue) || {})
   })
 }
 

--- a/src/weex/viewport.js
+++ b/src/weex/viewport.js
@@ -51,6 +51,7 @@ let screenHeight = 0
 const info = {
   dpr,
   scale: 0,
+  rootValue: 0,
   rem: 0,
   deviceWidth: 0,
   deviceHeight: 0
@@ -152,6 +153,7 @@ export function init (viewportWidth = width) {
 
     extend(info, {
       scale,
+      rootValue: viewportWidth / 10,
       deviceWidth: screenWidth * dpr,
       deviceHeight: screenHeight * dpr
     })


### PR DESCRIPTION
I found when the `weex-viewport` value is not 750, animation (H5) function will still use `75` as the `rootValue`.

So, `weex.config.env` should add `rootValue` props and animation value should be scaled.