### PR TITLE
Support render the <gif> component as <image>

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -89,6 +89,7 @@ export default {
     'container',
     'text',
     'image',
+    'gif',
     'img',
     'cell',
     'a'

--- a/src/core/node.js
+++ b/src/core/node.js
@@ -57,7 +57,7 @@ export function trimTextVNodes (vnodes) {
 
 // should share with precompiler.
 const metaMap = {
-  figure: ['img', 'image', 'figure'],
+  figure: ['img', 'image', 'gif', 'figure'],
   p: ['text', 'p'],
   div: ['container', 'div'],
   section: ['cell']
@@ -318,7 +318,7 @@ function transformAttrs (data, tag) {
     attrs = data.attrs = {}
   }
   attrs['weex-type'] = tag
-  if (tag === 'image') {
+  if (tag === 'image' || tag === 'gif') {
     const { src, resize } = attrs
     if (src) {
       attrs['data-img-src'] = src


### PR DESCRIPTION
Refer to https://github.com/weexteam/weex-vue-precompiler/pull/5

In order to enable the preprocessing of `<gif>` component, the `metaMap` here should also be modified.